### PR TITLE
Added `sourceOptions` param to use with `got`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ import parse from 'datex2-linker-api';
  * Parse a xml datex2 feed into a json-ld feed
  * @param  {string} source  a valid URL that goes to an xml datex2 feed
  * @param  {string} baseuri the baseuri that contains each identifier (as a hash)
+ * @param  {[object]} sourceOptions any of the `http.request` options.
  * @return {Promise}        will return the json-ld once parsing has completed
  */
-parse(source, baseuri).then(res=>{
+parse(source, baseuri, sourceOptions).then(res=>{
   console.log(res); // an object with the same value as the original xml
 }).catch(err=>{
   console.error(err); // 'error while parsing xml. ...'

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const context = {
  * Parse a xml datex2 feed into a json-ld feed
  * @param  {string} source  a valid URL that goes to an xml datex2 feed
  * @param  {string} baseuri the baseuri that contains each identifier (as a hash)
- * @param  {[object]} sourceOptions Any of the `http.request` options.
+ * @param  {[object]} sourceOptions any of the `http.request` options.
  * @return {Promise}        will return the json-ld once parsing has completed
  */
 function parse(source, baseuri, sourceOptions) {

--- a/index.js
+++ b/index.js
@@ -15,12 +15,13 @@ const context = {
  * Parse a xml datex2 feed into a json-ld feed
  * @param  {string} source  a valid URL that goes to an xml datex2 feed
  * @param  {string} baseuri the baseuri that contains each identifier (as a hash)
+ * @param  {[object]} sourceOptions Any of the `http.request` options.
  * @return {Promise}        will return the json-ld once parsing has completed
  */
-function parse(source, baseuri) {
+function parse(source, baseuri, sourceOptions) {
   return new Promise((resolve, reject) => {
     // get the requested source datafeed
-    got(source).then(response => {
+    got(source, sourceOptions).then(response => {
       // options for parsing the xml
       const parser = new xml2js.Parser({
         mergeAttrs: true,


### PR DESCRIPTION
This fixes if there's need for extra http.request options to be sent, such as authentication and so on.